### PR TITLE
Maximum chunk sizes

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -126,6 +126,11 @@ Incremental: ?1
 <content is an Encapsulated Request>
 ~~~
 
+Implementations MUST support receiving chunks that contain `2^14` (16384) octets
+of data prior to encapsulation. Senders of chunks SHOULD limit their chunks to
+this size, unless they are aware of support for larger sizes by the receiving
+party.
+
 # Request Format {#request}
 
 Chunked OHTTP requests start with the same header as used for the non-chunked variant,


### PR DESCRIPTION
Limit to 16K chunk sizes. This currently defines it as the plaintext size, but we could also include the tag to be the full chunk length. I don't have a strong opinion here.

Closes #7 