### PR TITLE
Add details on counter encoding

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -322,6 +322,13 @@ integer with `Nn` bits (that maximum being `2^Nn`), where `Nn` is the
 length of the AEAD nonce, the `chunk_nonce` would wrap and be reused.
 Therefore, the response MUST NOT use `2^Nn` or more chunks.
 
+For successful decryption, the sender and receiver need to encode the counter
+to the same binary values.
+
+The `encode(Nn, counter)` function must encode the counter in Big Endian
+encoding. If counter is shorter than `Nn`, it should be padded by prefixing
+zero bytes.
+
 # Security Considerations {#security}
 
 In general, Chunked OHTTP inherits the same security considerations as Oblivious


### PR DESCRIPTION
First of all, thanks for the great work on this Draft RFC, it's been very useful so far!

I've been working on implementing chunked responses and I would suggest to add a bit more detail on the counter encoding.

If I understand correctly, senders and receivers will need to use the same encoding to end up with the same `chunk_nonce`. To maintain compatibility between different implementations I think it would be good to have this encoding spelled out in the RFC.

In the PR I suggest we specify to use Big Endian encoding, but that's just to illustrate the level of detail I'm suggesting. If a different encoding is more appropriate, I'd be happy to make changes.

