### PR TITLE
Add Transfer-Encoding to the example

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -139,6 +139,7 @@ POST /request.example.net/proxy HTTP/1.1
 Host: proxy.example.org
 Content-Type: message/ohttp-chunked-req
 Incremental: ?1
+Transfer-Encoding: chunked
 
 <content is an Encapsulated Request>
 ~~~


### PR DESCRIPTION
This is required for compliance with RFC 9112, Section 6, which says

> The presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding header field.

The text notes that Content-Length would be unusual, so Transfer-Encoding must be the common case with HTTP/1.1.