### PR TITLE
Use repeated field notation for non-final request/response chunk.

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -173,7 +173,7 @@ Chunked Request Header {
 }
 
 Chunked Request Chunks {
-  Non-Final Request Chunk (..),
+  Non-Final Request Chunk (..) ...,
   Final Request Chunk Indicator (i) = 0,
   HPKE-Protected Final Chunk (..),
 }
@@ -201,7 +201,7 @@ Chunked Encapsulated Response {
 }
 
 Chunked Response Chunks {
-  Non-Final Response Chunk (..),
+  Non-Final Response Chunk (..) ...,
   Final Response Chunk Indicator (i) = 0,
   AEAD-Protected Final Response Chunk (..),
 }


### PR DESCRIPTION
There can be 0 or more non-final request/response chunks