### PR TITLE
Response chunk counter limit fix

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -328,9 +328,9 @@ final_chunk = concat(varint_encode(0), sealed_final_chunk)
 ~~~
 
 If the counter reached the maximum value that can be held in an
-integer with `Nn` bytes (that maximum being `256^Nn`), where `Nn` is the
+integer with `Nn` bytes (that maximum being 256<sup>`Nn`</sup>), where `Nn` is the
 length of the AEAD nonce, the `chunk_nonce` would wrap and be reused.
-Therefore, the response MUST NOT use `256^Nn` or more chunks.
+Therefore, the response MUST NOT use 256<sup>`Nn`</sup> or more chunks.
 
 # Security Considerations {#security}
 

--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -328,9 +328,9 @@ final_chunk = concat(varint_encode(0), sealed_final_chunk)
 ~~~
 
 If the counter reached the maximum value that can be held in an
-integer with `Nn` bits (that maximum being `2^Nn`), where `Nn` is the
+integer with `Nn` bytes (that maximum being `256^Nn`), where `Nn` is the
 length of the AEAD nonce, the `chunk_nonce` would wrap and be reused.
-Therefore, the response MUST NOT use `2^Nn` or more chunks.
+Therefore, the response MUST NOT use `256^Nn` or more chunks.
 
 # Security Considerations {#security}
 


### PR DESCRIPTION
The response chunk counter is encoded to `Nn`, which is the nonce length in bytes. This means that the encoded counter can support integer values that can fit in `Nn` bytes, so the `chunk_nonce` would wrap at 256^Nn.