### PR TITLE
Add a brief analysis of MU bounds

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -334,7 +334,6 @@ Therefore, the response MUST NOT use 256<sup>`Nn`</sup> or more chunks.
 However, this limit does not consider security margins; see {{sec-limits}}.
 
 
-
 # Security Considerations {#security}
 
 In general, Chunked OHTTP inherits the same security considerations as Oblivious


### PR DESCRIPTION
AES-GCM isn't that great under a multi-user analysis here.  1GB messages aren't tiny, but they aren't exactly generous either (you can loosen the advantage; 2^-50 is somewhat arbitrary.  Still, ChaCha20Poly1305 starts looking a lot better by comparison.