### PR TITLE
Fix naming of KEM encapsulated key

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -169,7 +169,7 @@ Chunked Request Header {
   HPKE KEM ID (16),
   HPKE KDF ID (16),
   HPKE AEAD ID (16),
-  Encapsulated KEM Shared Secret (8 * Nenc),
+  KEM Encapsulated Key (8 * Nenc),
 }
 
 Chunked Request Chunks {


### PR DESCRIPTION
Just a nit. The term for the thing the client sends is "encapsulated key" not "encapsulated shared secret" (in fact, the shared secret is not equal to the thing you get when you decapsulate, but rather a hash of it with some other stuff)