### PR TITLE
Zero-length chunks are a DoS vector

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -481,6 +481,19 @@ no message can exceed 2<sup>40</sup> bytes
 protected with AEAD_AES_GCM_128.
 
 
+## Zero-Length Chunks
+
+A malicious sender can construct a chunked encapsulation
+that requires the recipient expend pointless effort on decryption,
+without transmitting any data.
+
+There is no significant reason to transmit empty chunks,
+other than the final chunk.
+An implemention could choose to abort a request
+if the number of empty chunks received
+exceed an implementation-determined limit.
+
+
 # IANA Considerations
 
 This document updates the "Media Types" registry at


### PR DESCRIPTION
They might be used for padding of a sort, but it's a crude tool.  The only real reason you might need a zero-length chunk is for the final chunk. Other instances are immediately suspect.