### PR TITLE
We never really said this before

### DIFF
--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -129,7 +129,8 @@ a successful corresponding response MUST use the media type "message/ohttp-chunk
 Chunked Oblivious HTTP requests are defined to contain Binary HTTP requests
 in either Known- or Indeterminate-Length form;
 responses contain Binary HTTP responses; see {{!BHTTP}}. As with non-chunked Oblivious HTTP, the encapsulation format
-of chunked Oblivious HTTP can be repurposed for other media types. See {{Section 4.6 of OHTTP}}.
+of chunked Oblivious HTTP can be repurposed for other media types;
+see {{Section 4.6 of OHTTP}}.
 
 Use cases that require the use of Chunked OHTTP SHOULD only use the chunked
 media types for their requests, to indicate that Chunked OHTTP is required.

--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -129,7 +129,7 @@ a successful corresponding response MUST use the media type "message/ohttp-chunk
 Chunked Oblivious HTTP requests are defined to contain Binary HTTP requests
 in either Known- or Indeterminate-Length form;
 responses contain Binary HTTP responses; see {{!BHTTP}}.
-As with non-chunked Oblivious HTTP, 
+As with non-chunked Oblivious HTTP,
 the encapsulation format of chunked Oblivious HTTP can be repurposed
 for other media types; see {{Section 4.6 of OHTTP}}.
 

--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -126,6 +126,10 @@ and "message/ohttp-chunked-res" (defined in {{iana-res}}).
 If a request uses the media type "message/ohttp-chunked-req",
 a successful corresponding response MUST use the media type "message/ohttp-chunked-res".
 
+Chunked Oblivious HTTP requests MUST contain Binary HTTP requests
+in either Known- or Indeterminate-Length form;
+responses MUST contain Binary HTTP responses; see {{!BHTTP}}.
+
 Use cases that require the use of Chunked OHTTP SHOULD only use the chunked
 media types for their requests, to indicate that Chunked OHTTP is required.
 If the gateway unexpectedly does not support Chunked OHTTP, then the request

--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -126,9 +126,10 @@ and "message/ohttp-chunked-res" (defined in {{iana-res}}).
 If a request uses the media type "message/ohttp-chunked-req",
 a successful corresponding response MUST use the media type "message/ohttp-chunked-res".
 
-Chunked Oblivious HTTP requests MUST contain Binary HTTP requests
+Chunked Oblivious HTTP requests are defined to contain Binary HTTP requests
 in either Known- or Indeterminate-Length form;
-responses MUST contain Binary HTTP responses; see {{!BHTTP}}.
+responses contain Binary HTTP responses; see {{!BHTTP}}. As with non-chunked Oblivious HTTP, the encapsulation format
+of chunked Oblivious HTTP can be repurposed for other media types. See {{Section 4.6 of OHTTP}}.
 
 Use cases that require the use of Chunked OHTTP SHOULD only use the chunked
 media types for their requests, to indicate that Chunked OHTTP is required.

--- a/draft-ietf-ohai-chunked-ohttp.md
+++ b/draft-ietf-ohai-chunked-ohttp.md
@@ -128,9 +128,10 @@ a successful corresponding response MUST use the media type "message/ohttp-chunk
 
 Chunked Oblivious HTTP requests are defined to contain Binary HTTP requests
 in either Known- or Indeterminate-Length form;
-responses contain Binary HTTP responses; see {{!BHTTP}}. As with non-chunked Oblivious HTTP, the encapsulation format
-of chunked Oblivious HTTP can be repurposed for other media types;
-see {{Section 4.6 of OHTTP}}.
+responses contain Binary HTTP responses; see {{!BHTTP}}.
+As with non-chunked Oblivious HTTP, 
+the encapsulation format of chunked Oblivious HTTP can be repurposed
+for other media types; see {{Section 4.6 of OHTTP}}.
 
 Use cases that require the use of Chunked OHTTP SHOULD only use the chunked
 media types for their requests, to indicate that Chunked OHTTP is required.


### PR DESCRIPTION
RFC 9458 says that the content of the message is Binary HTTP; this never did.

Closes #57